### PR TITLE
Compile under Qt5.4. Please review the use of toUtf8 instead of toAscii

### DIFF
--- a/editor/actions/get_user_input.cpp
+++ b/editor/actions/get_user_input.cpp
@@ -34,7 +34,7 @@ GetUserInput::GetUserInput(const QVariantMap& data, QObject *parent):
 
     QTextCodec * codec = QTextCodec::codecForName("utf-8");
     if (! codec)
-        codec = QTextCodec::codecForTr();
+        codec = QTextCodec::codecForLocale();
 
     if (data.contains("message") && data.value("message").type() == QVariant::String)
         mMessage = codec->toUnicode( data.value("message").toByteArray());
@@ -129,7 +129,7 @@ QVariantMap GetUserInput::toJsonObject()
 
     QTextCodec *codec = QTextCodec::codecForName("UTF-8");
     if (! codec)
-        codec = QTextCodec::codecForTr();
+        codec = QTextCodec::codecForLocale();
 
     object.insert("message", mMessage);
     object.insert("variable", mVariable);

--- a/editor/add_character_dialog.cpp
+++ b/editor/add_character_dialog.cpp
@@ -45,7 +45,7 @@ void AddCharacterDialog::init(Character* character)
     mPrevName = "";
     mUi.lImage->setAlignment(Qt::AlignCenter);
     mUi.browseImageButton->setFilter(ChooseFileButton::ImageFilter);
-    mUi.statusTreeWidget->header()->setResizeMode(0, QHeaderView::Stretch);
+    mUi.statusTreeWidget->header()->setSectionResizeMode(0,QHeaderView::Stretch);
     mUi.statusTreeWidget->setIconSize(QSize(32, 32));
 
     if (character) {

--- a/editor/belle.cpp
+++ b/editor/belle.cpp
@@ -78,7 +78,7 @@ Belle::Belle(QWidget *widget)
 
     mHttpServer.setServerPort(8000);
     mDisableClick = false;
-    QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
+    QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
 
     //setup scenes
     Scene::setEditorWidget(new SceneEditorWidget);

--- a/editor/belle.pro
+++ b/editor/belle.pro
@@ -10,7 +10,7 @@ DEPENDPATH += actions objects
 TARGET = belle
 TARGET.path = $$PREFIX/
 CONFIG+=debug
-QT += network webkit
+QT += core widgets network webkitwidgets
 
 FORMS += mainwindow.ui\
     novel_properties_dialog.ui \
@@ -37,8 +37,8 @@ HEADERS      += belle.h\
     actions_view.h \
     actions_model.h \
     actions/wait.h \
-    action_editor_widget.h \
-    wait_editor_widget.h \
+    actions/action_editor_widget.h \
+    actions/wait_editor_widget.h \
     actions/dialogue.h \
     actions/dialogue_editor_widget.h \
     objects/dialoguebox.h \

--- a/editor/json.cpp
+++ b/editor/json.cpp
@@ -553,7 +553,7 @@ int Json::nextToken(const QString &json, int &index)
 
         QChar c = json[index];
         index++;
-        switch(c.toAscii())
+        switch(c.toLatin1())
         {
                 case '{': return JsonTokenCurlyOpen;
                 case '}': return JsonTokenCurlyClose;

--- a/editor/main.cpp
+++ b/editor/main.cpp
@@ -14,7 +14,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <QtGui/QApplication>
+#include <QApplication>
 
 #include <QTimer>
 #include <QDebug>

--- a/editor/novel_properties_dialog.cpp
+++ b/editor/novel_properties_dialog.cpp
@@ -18,9 +18,10 @@
 
 #include <QFileDialog>
 #include <QDebug>
-#include <QDesktopServices>
+#include <QStandardPaths>
 #include <QFontDatabase>
 #include <QMessageBox>
+
 
 #include "engine.h"
 
@@ -141,7 +142,7 @@ void NovelPropertiesDialog::updateTextSpeedSliderTooltip(int val)
 void NovelPropertiesDialog::onBrowserSelect()
 {
     QString filter = "";
-    QString startPath = QDesktopServices::storageLocation(QDesktopServices::ApplicationsLocation);
+    QString startPath = QString(QStandardPaths::DocumentsLocation);
 
 #if defined(Q_WS_X11)
     if (startPath.isEmpty()) {

--- a/editor/objectsview.cpp
+++ b/editor/objectsview.cpp
@@ -7,7 +7,7 @@ ObjectsView::ObjectsView(QWidget *parent) :
     PropertiesWidget(parent, 1)
 {
     this->setHeaderHidden(true);
-    this->header()->setResizeMode(QHeaderView::ResizeToContents);
+    this->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     connect(this, SIGNAL(clicked(const QModelIndex&)), this, SLOT(itemClicked(const QModelIndex&)));
 }
 

--- a/editor/resource_manager.cpp
+++ b/editor/resource_manager.cpp
@@ -444,7 +444,7 @@ void ResourceManager::exportCustomFonts(const QDir& dir)
             fontName = families[0];
 
         //write css for font
-        file.write(Utils::fontFace(fontName).toAscii());
+        file.write(Utils::fontFace(fontName).toUtf8());
         file.write("\n");
     }
 

--- a/editor/simple_http_server.cpp
+++ b/editor/simple_http_server.cpp
@@ -55,7 +55,7 @@ void SimpleHttpServer::readClient()
             QStringList header;
             QString file = tokens[1];
             QString path = fullPath(file);
-            QByteArray data = QString("No index.html or index.htm found on \"%1\". :(").arg(mDirectory.absolutePath()).toAscii();
+            QByteArray data = QString("No index.html or index.htm found on \"%1\". :(").arg(mDirectory.absolutePath()).toUtf8();
             QString ctype = "text/plain";
             QString modified = "";
             QString charset("");
@@ -81,7 +81,7 @@ void SimpleHttpServer::readClient()
                  << "\r\n";
             }
 
-            socket->write(header.join("").toAscii());
+            socket->write(header.join("").toUtf8());
             if (data.size())
                 socket->write(data);
             socket->disconnectFromHost();
@@ -166,7 +166,7 @@ QString SimpleHttpServer::fullPath(QString path)
 {
     path = path.split('?')[0];
     path = path.split('#')[0];
-    path = QUrl::fromPercentEncoding(path.toAscii());
+    path = QUrl::fromPercentEncoding(path.toUtf8());
     path = QDir::cleanPath(path);
     QStringList words = path.split('/', QString::SkipEmptyParts);
     QDir dir = mDirectory;


### PR DESCRIPTION
As we can install Qt 4 and 5 side by side and almost every distribution have the newer, even Debian Wheezy trough backports, I started to port Belle. With this minimal changes I can compile in 5.4.
But I'm not sure if `toAscii` can be changed to `toUtf8` without side effects to other part of code or if it should be `toLatin1`.
